### PR TITLE
✨ feat(settings): add settings activity with data deletion feature

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,16 @@
                  android:value=".MainActivity" />
          </activity>
 
+        <activity
+            android:name=".SettingsActivity"
+            android:exported="false"
+            android:label="@string/settings_title"
+            android:parentActivityName=".MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".MainActivity" />
+        </activity>
+
         <service
                 android:name=".NotificationListener"
                 android:label="@string/notification_listener_service_label"

--- a/app/src/main/java/fr/loicnogier/mystreamlogs/MainActivity.kt
+++ b/app/src/main/java/fr/loicnogier/mystreamlogs/MainActivity.kt
@@ -157,6 +157,11 @@ class MainActivity : AppCompatActivity() {
                     startActivity(intent)
                     false
                 }
+                R.id.navigation_settings -> {
+                    val intent = Intent(this, SettingsActivity::class.java)
+                    startActivity(intent)
+                    false
+                }
                 else -> false
             }
         }
@@ -253,7 +258,9 @@ class MainActivity : AppCompatActivity() {
                 .setTitle(getString(R.string.permission_post_notifications_title))
                 .setMessage(getString(R.string.permission_post_notifications_message))
                 .setPositiveButton(getString(R.string.permission_post_notifications_button_grant)) { _, _ ->
-                    requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                    }
                 }
                 .setNegativeButton(getString(R.string.permission_post_notifications_button_deny), null)
                 .show()

--- a/app/src/main/java/fr/loicnogier/mystreamlogs/SettingsActivity.kt
+++ b/app/src/main/java/fr/loicnogier/mystreamlogs/SettingsActivity.kt
@@ -1,0 +1,75 @@
+package fr.loicnogier.mystreamlogs
+
+import android.os.Bundle
+import android.view.MenuItem
+import android.widget.Button
+import android.widget.Toast
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.lifecycle.lifecycleScope
+import com.google.android.material.appbar.MaterialToolbar
+import kotlinx.coroutines.launch
+
+class SettingsActivity : AppCompatActivity() {
+
+    private lateinit var toolbar: MaterialToolbar
+    private lateinit var deleteDataButton: Button
+
+    private val database by lazy { AppDatabase.getDatabase(this) }
+    private val trackHistoryDao by lazy { database.trackHistoryDao() }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContentView(R.layout.activity_settings)
+
+        toolbar = findViewById(R.id.toolbar)
+        deleteDataButton = findViewById(R.id.deleteDataButton)
+
+        setSupportActionBar(toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { view, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            view.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
+
+        setupDeleteButton()
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            finish() // Ferme cette activité et retourne à la précédente
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+
+    private fun setupDeleteButton() {
+        deleteDataButton.setOnClickListener {
+            showDeleteConfirmationDialog()
+        }
+    }
+
+    private fun showDeleteConfirmationDialog() {
+        AlertDialog.Builder(this)
+            .setTitle(R.string.settings_delete_confirmation_dialog_title)
+            .setMessage(R.string.settings_delete_confirmation_dialog_message)
+            .setPositiveButton(R.string.settings_delete_confirmation_dialog_confirm) { _, _ ->
+                deleteAllUserData()
+            }
+            .setNegativeButton(R.string.settings_delete_confirmation_dialog_cancel, null)
+            .show()
+    }
+
+    private fun deleteAllUserData() {
+        lifecycleScope.launch {
+            trackHistoryDao.deleteAll()
+            Toast.makeText(this@SettingsActivity, getString(R.string.data_deleted_toast), Toast.LENGTH_SHORT).show()
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                                                     xmlns:app="http://schemas.android.com/apk/res-auto"
+                                                     xmlns:tools="http://schemas.android.com/tools"
+                                                     android:layout_width="match_parent"
+                                                     android:layout_height="match_parent"
+                                                     android:fitsSystemWindows="true"
+                                                     tools:context=".SettingsActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+            android:fitsSystemWindows="true">
+
+        <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                app:title="@string/settings_title" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior"
+            android:padding="16dp">
+
+        <Button
+                android:id="@+id/deleteDataButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_delete_data_button"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:layout_marginTop="24dp"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -9,4 +9,9 @@
             android:id="@+id/navigation_most_streamed"
             android:icon="@drawable/ic_most_streamed"
             android:title="@string/bottom_nav_most_streamed" />
+
+    <item
+            android:id="@+id/navigation_settings"
+            android:icon="@android:drawable/ic_menu_manage"
+            android:title="@string/bottom_nav_settings" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,16 @@
     <string name="bottom_nav_most_streamed">Most Streamed</string>
     <string name="search_hint">Search History…</string>
 
+    <!-- Settings Page Strings -->
+    <string name="settings_title">Settings</string>
+    <string name="settings_delete_data_button">Delete All Music Data</string>
+    <string name="settings_delete_confirmation_dialog_title">Confirm Deletion</string>
+    <string name="settings_delete_confirmation_dialog_message">Are you sure you want to delete all music data? This action cannot be undone.</string>
+    <string name="settings_delete_confirmation_dialog_confirm">Delete</string>
+    <string name="settings_delete_confirmation_dialog_cancel">Cancel</string>
+    <string name="bottom_nav_settings">Settings</string>
+    <string name="data_deleted_toast">All music data has been deleted.</string>
+
     <plurals name="stream_count_text">
         <item quantity="one">%d stream</item>
         <item quantity="other">%d streams</item>


### PR DESCRIPTION
- introduce a new SettingsActivity for managing user preferences
- add navigation to settings from the bottom navigation menu
- implement data deletion functionality with confirmation dialog
- update strings.xml for new settings-related text
- create activity_settings layout with a delete data button
- ensure edge-to-edge design compatibility in SettingsActivity